### PR TITLE
fix: handle broken symlinks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,8 @@ fi
 mkdir -p $cache_dir/out
 rm -f $cache_dir/out/*
 TARBALL="$cache_dir/out/$APP-$VERSION.tar.gz"
-tar zcf $TARBALL --dereference --exclude='*.apt/usr/share/doc/*' -C _build/${RELEASE_ENV}/rel/$APP/ .
+delete_broken_symlinks "_build/${RELEASE_ENV}/rel/${APP}/"
+tar zcf $TARBALL --dereference -C _build/${RELEASE_ENV}/rel/$APP/ .
 
 # so it can be deleted outside of container
 chmod +w $cache_dir/out/$APP-$VERSION.tar.gz

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -72,3 +72,7 @@ output_section() {
   local indentation="----->"
   echo "${indentation} $1"
 }
+
+delete_broken_symlinks() {
+  find "$1" -xtype l -delete > /dev/null
+}

--- a/test/handle_broken_symlinks.sh
+++ b/test/handle_broken_symlinks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/.test_support.sh
+
+# include source file
+source $SCRIPT_DIR/../lib/build.sh
+
+# TESTS
+######################
+suite "delete_broken_symlinks"
+
+  test_dir=$(mktemp -d)
+
+  test "leaves good symlink"
+    touch "$test_dir/real_file"
+    ln -s "$test_dir/real_file" "$test_dir/symlink"
+
+    delete_broken_symlinks "${test_dir}"
+
+    [ -e "$test_dir/symlink" ]
+
+  test "deletes broken symlink"
+    rm "$test_dir/real_file"
+
+    delete_broken_symlinks "${test_dir}"
+
+    [ ! -e "$test_dir/symlink" ]
+
+
+
+PASSED_ALL_TESTS=true


### PR DESCRIPTION
The apt buildpack causes broken symlinks in the build directory.

This PR will remove any broken symlinks before the tarball is created.
