### PR TITLE
refactor: extract output funcs to shared lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,4 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: run tests
-      run: |
-        for tst in test/*; do $tst; done
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+
+test:
+	@set -e; for tst in test/*.sh; do \
+		[ -x "$$tst" ] || continue; \
+		"$$tst"; \
+	done

--- a/bin/compile
+++ b/bin/compile
@@ -16,6 +16,7 @@ cache_dir=$(cd $2 && pwd)
 env_path=$(cd $3 && pwd)
 build_pack_dir=$(cd $(dirname $(dirname $0)); pwd)
 
+source ${build_pack_dir}/lib/output_funcs.sh
 source ${build_pack_dir}/lib/build.sh
 
 load_config

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -63,16 +63,6 @@ distillery_mix_release_command() {
   set -o errexit    # always exit on error
 }
 
-output_line() {
-  local spacing="      "
-  echo "${spacing} $1"
-}
-
-output_section() {
-  local indentation="----->"
-  echo "${indentation} $1"
-}
-
 delete_broken_symlinks() {
   find "$1" -xtype l -delete > /dev/null
 }

--- a/lib/output_funcs.sh
+++ b/lib/output_funcs.sh
@@ -1,0 +1,56 @@
+# Outputs section heading
+#
+# Usage:
+#
+#     output_section "Application tasks"
+#
+output_section() {
+  local indentation="----->"
+  echo "${indentation} $1"
+}
+
+# Outputs log line
+#
+# Usage:
+#
+#     output_line "Cloning repository"
+#
+output_line() {
+  local spacing="      "
+  echo "${spacing} $1"
+}
+
+# Outputs a warning in red
+#
+# Usage:
+#
+#     output_warning "Something went wrong"
+#
+output_warning() {
+  local spacing="      "
+  echo -e "${spacing} \e[31m$1\e[0m"
+}
+
+# Outputs to stderr for debugging
+#
+# Usage:
+#
+#     output_stderr "Debug info"
+#
+output_stderr() {
+  # Outputs to stderr in case it is inside a function so it does not
+  # disturb the return value. Useful for debugging.
+  echo "$@" 1>&2;
+}
+
+# Pipe processor for indenting command output
+#
+# Usage:
+#
+#     command | output_indent
+#
+output_indent() {
+  while read LINE; do
+    echo "       $LINE" || true
+  done
+}

--- a/test/.test_support.sh
+++ b/test/.test_support.sh
@@ -1,46 +1,13 @@
 #!/usr/bin/env bash
 
-
-ROOT_DIR=$(dirname "$SCRIPT_DIR")
-PASSED_ALL_TESTS=false
-
-# make a temp dir for test files/directories
-TEST_DIR=$(mktemp -d -t gigalixir-buildpack-phoenix-static_XXXXXXXXXX)
-ECHO_CONTENT=()
-cleanup() {
-  rm -rf ${TEST_DIR}
-  if $PASSED_ALL_TESTS; then
-    /bin/echo -e "  \e[0;32mTest Suite PASSED\e[0m"
-  else
-    /bin/echo -e "  \e[0;31mFAILED\e[0m"
-  fi
-  exit
-}
-trap cleanup EXIT INT TERM
+REPO_NAME="gigalixir-buildpack-releases"
+source "$(dirname "${BASH_SOURCE[0]}")/test_framework.sh"
 
 buildpack_dir=$(cd $(dirname $0)/.. && pwd)
+build_pack_dir=${ROOT_DIR}
 
 # create directories for test
 assets_dir=${TEST_DIR}/assets_dir
 build_dir=${TEST_DIR}/build_dir
 cache_dir=${TEST_DIR}/cache_dir
-build_pack_dir=${ROOT_DIR}
 mkdir -p ${assets_dir} ${build_dir} ${cache_dir}
-
-
-# overridden functions
-info() {
-  true
-}
-
-# helper functions
-test() {
-  failed=false
-  ECHO_CONTENT=()
-  /bin/echo "  TEST: $@"
-}
-
-suite() {
-  failed=false
-  /bin/echo -e "\e[0;36mSUITE: $@\e[0m"
-}

--- a/test/test_framework.sh
+++ b/test/test_framework.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Shared test framework for gigalixir buildpack repos.
+#
+# Prerequisites (must be set before sourcing):
+#   SCRIPT_DIR  - absolute path to the test/ directory
+#   REPO_NAME   - name used in the mktemp template
+#
+
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+PASSED_ALL_TESTS=false
+ECHO_CONTENT=()
+
+# make a temp dir for test files/directories
+TEST_DIR=$(mktemp -d -t "${REPO_NAME}_XXXXXXXXXX")
+
+cleanup() {
+  rm -rf ${TEST_DIR}
+  if $PASSED_ALL_TESTS; then
+    /bin/echo -e "  \e[0;32mTest Suite PASSED\e[0m"
+  else
+    /bin/echo -e "  \e[0;31mFAILED\e[0m"
+  fi
+  exit
+}
+trap cleanup EXIT INT TERM
+
+# stub output functions to suppress noise in tests
+output_section() {
+  true
+}
+output_line() {
+  true
+}
+output_warning() {
+  true
+}
+output_stderr() {
+  true
+}
+output_indent() {
+  cat > /dev/null
+}
+
+# helper functions
+test() {
+  reset_test
+  failed=false
+  ECHO_CONTENT=()
+  /bin/echo "  TEST: $@"
+}
+
+suite() {
+  failed=false
+  /bin/echo -e "\e[0;36mSUITE: $@\e[0m"
+}
+
+reset_test() {
+  true
+}


### PR DESCRIPTION
## Summary

Standardizes shared infrastructure across the 4 gigalixir buildpack repos (elixir, mix, phoenix-static, releases).

### Output functions (`lib/output_funcs.sh`)
- Extracts `output_section`, `output_line`, `output_warning`, `output_stderr`, and `output_indent` into a shared `lib/output_funcs.sh`
- Replaces inline definitions and legacy function names (`info`, `indent`, `header`) with the standardized versions
- The shared file is identical across all 4 repos

### Test framework (`test/test_framework.sh`)
- Extracts common test plumbing (cleanup/trap, output stubs, `test()`/`suite()`/`reset_test()` helpers) into a shared `test/test_framework.sh`
- Each repo's `test/.test_support.sh` is now a thin wrapper that sets repo-specific variables and sources the framework
- The framework file is identical across all 4 repos

### Makefile
- Adds a `Makefile` with a default `test` target that runs all executable test files
- Updates CI workflow to use `make test`

## Test plan
- [x] All tests pass locally via `make test` in each repo
- [x] CI passes on all 4 PRs